### PR TITLE
Use `jenkins.baseline` to reduce bom update mistakes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,10 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.190.3</jenkins.version>
-    <jenkins.bom.artifactId>2.190.x</jenkins.bom.artifactId>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.190</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.bom.artifactId>2.${jenkins.baseline}.x</jenkins.bom.artifactId>
     <jenkins.bom.version>16</jenkins.bom.version>
     <java.level>8</java.level>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.190</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <jenkins.bom.artifactId>2.${jenkins.baseline}.x</jenkins.bom.artifactId>
+    <jenkins.bom.artifactId>${jenkins.baseline}.x</jenkins.bom.artifactId>
     <jenkins.bom.version>16</jenkins.bom.version>
     <java.level>8</java.level>
   </properties>


### PR DESCRIPTION
## Use `jenkins.baseline` in `pom.xml`

This change is proposed by the plugin archetype and makes maintenance of `jenkins.version` and `bom` a little easier.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
